### PR TITLE
KKB-87 added wrapper-div to faq-list

### DIFF
--- a/ding_faq.views_default.inc
+++ b/ding_faq.views_default.inc
@@ -87,7 +87,8 @@ function ding_faq_views_default_views() {
   $handler->display->display_options['fields']['field_ding_faq_category']['element_type'] = 'span';
   $handler->display->display_options['fields']['field_ding_faq_category']['element_class'] = 'news-label';
   $handler->display->display_options['fields']['field_ding_faq_category']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_ding_faq_category']['element_wrapper_type'] = '0';
+  $handler->display->display_options['fields']['field_ding_faq_category']['element_wrapper_type'] = 'div';
+  $handler->display->display_options['fields']['field_ding_faq_category']['element_wrapper_class'] = 'news-sub-heading';
   $handler->display->display_options['fields']['field_ding_faq_category']['element_default_classes'] = FALSE;
   /* Field: Content: Lead */
   $handler->display->display_options['fields']['field_ding_faq_lead']['id'] = 'field_ding_faq_lead';


### PR DESCRIPTION
Since news-label should display above heading:
a wrapper div needs to be added around it in order to follow the general styling for news-labels.
